### PR TITLE
Add config option to define a guest redirect URL

### DIFF
--- a/config/filament-form-builder.php
+++ b/config/filament-form-builder.php
@@ -32,4 +32,6 @@ return [
     'admin-panel-filament-form-field-name-plural' => 'Fields',
 
     'preview-route' => 'filament-form-builder.show',
+
+    'form-guest-redirect-url' => null,
 ];

--- a/src/Middleware/CheckFormGuestAccess.php
+++ b/src/Middleware/CheckFormGuestAccess.php
@@ -23,7 +23,16 @@ class CheckFormGuestAccess
             return $next($request);
         }
 
-        // Otherwise, redirect to login
-        return redirect()->guest(route('login'));
+        // If a custom guest redirect url has been set
+        if (config('filament-form-builder.form-guest-redirect-url')) {
+            return redirect()->guest(config('filament-form-builder.form-guest-redirect-url'));
+        }
+
+        try {
+            // Otherwise, redirect to login
+            return redirect()->guest(route('login'));
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage() . ' ' . __('Use config option "form-guest-redirect-url" to set a custom redirect URL.'));
+        }
     }
 }


### PR DESCRIPTION
# Details

Add an option to customize the redirection url in case route('login') is not defined.

# Steps to test changes

1. create a form without guest access
2. set option ”form-guest-redirect-url” to an URL
3. visit the created form without beeing logged in
4. verify that you get redirected to your defined URL