### PR TITLE
Add UUID to FilamentForm and FilamentFormUser

### DIFF
--- a/database/migrations/add_uuid_to_filament_form_user.php.stub
+++ b/database/migrations/add_uuid_to_filament_form_user.php.stub
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('filament_form_user', function (Blueprint $table) {
+            $table->uuid('uuid')->after('id')->nullable();
+        });
+
+        foreach (DB::table('filament_form_user')->get() as $row) {
+            DB::table('filament_form_user')->where('id', $row->id)->update(['uuid' => Str::uuid()]);
+        }
+
+        Schema::table('filament_form_user', function (Blueprint $table) {
+            $table->uuid('uuid')->nullable(false)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('filament_form_user', function (Blueprint $table) {
+            $table->dropColumn('uuid');
+        });
+    }
+};

--- a/database/migrations/add_uuid_to_filament_forms.php.stub
+++ b/database/migrations/add_uuid_to_filament_forms.php.stub
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('filament_forms', function (Blueprint $table) {
+            $table->uuid('uuid')->after('id')->nullable();
+        });
+
+        foreach (DB::table('filament_forms')->get() as $row) {
+            DB::table('filament_forms')->where('id', $row->id)->update(['uuid' => Str::uuid()]);
+        }
+
+        Schema::table('filament_forms', function (Blueprint $table) {
+            $table->uuid('uuid')->nullable(false)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('filament_forms', function (Blueprint $table) {
+            $table->dropColumn('uuid');
+        });
+    }
+};

--- a/resources/views/livewire/filament-form-user/entry.blade.php
+++ b/resources/views/livewire/filament-form-user/entry.blade.php
@@ -4,7 +4,7 @@
             <h1 class="text-2xl font-bold mb-4">Form Submission</h1>
 
             <div class="entry-content">
-                @livewire('tapp.filament-form-builder.livewire.filament-form-user.show', ['entry' => $entry], key('entry-'.$entry->id))
+                @livewire('tapp.filament-form-builder.livewire.filament-form-user.show', ['entry' => $entry], key('entry-'.$entry->uuid))
             </div>
         </div>
     </div>

--- a/resources/views/livewire/filament-form/form.blade.php
+++ b/resources/views/livewire/filament-form/form.blade.php
@@ -2,7 +2,7 @@
     <div class="container mx-auto py-8">
         <div class="bg-white rounded-lg shadow-md p-6">
             <div class="form-content">
-                @livewire('tapp.filament-form-builder.livewire.filament-form.show', ['form' => $form], key('form-'.$form->id))
+                @livewire('tapp.filament-form-builder.livewire.filament-form.show', ['form' => $form], key('form-'.$form->uuid))
             </div>
         </div>
     </div>

--- a/src/Filament/Resources/FilamentFormResource.php
+++ b/src/Filament/Resources/FilamentFormResource.php
@@ -106,7 +106,7 @@ class FilamentFormResource extends Resource
                 EditAction::make(),
                 Action::make('preview')
                     ->visible(fn () => (bool) config('filament-form-builder.preview-route'))
-                    ->url(fn ($record) => route(config('filament-form-builder.preview-route'), ['form' => $record->id]))
+                    ->url(fn ($record) => route(config('filament-form-builder.preview-route'), ['form' => $record->uuid]))
                     ->openUrlInNewTab(),
                 Action::make('copy')
                     ->action(function ($record) {
@@ -136,7 +136,7 @@ class FilamentFormResource extends Resource
                             ->success()
                             ->send();
 
-                        return Redirect::to('/admin/filament-forms/'.$formCopy->id.'/edit');
+                        return Redirect::to('/admin/filament-forms/'.$formCopy->uuid.'/edit');
                     }),
             ])
             ->bulkActions([

--- a/src/Filament/Resources/FilamentFormResource/Pages/EditFilamentForm.php
+++ b/src/Filament/Resources/FilamentFormResource/Pages/EditFilamentForm.php
@@ -21,7 +21,7 @@ class EditFilamentForm extends EditRecord
             Actions\DeleteAction::make(),
             Actions\Action::make('preview')
                 ->visible(fn () => (bool) config('filament-form-builder.preview-route'))
-                ->url(fn ($record) => route(config('filament-form-builder.preview-route'), ['form' => $record->id]))
+                ->url(fn ($record) => route(config('filament-form-builder.preview-route'), ['form' => $record->uuid]))
                 ->openUrlInNewTab(),
         ];
     }

--- a/src/FilamentFormBuilderServiceProvider.php
+++ b/src/FilamentFormBuilderServiceProvider.php
@@ -23,6 +23,8 @@ class FilamentFormBuilderServiceProvider extends PackageServiceProvider
         $package->name('filament-form-builder')
             ->hasMigration('create_dynamic_filament_form_tables')
             ->hasMigration('add_schema_to_filament_form_fields')
+            ->hasMigration('add_uuid_to_filament_forms')
+            ->hasMigration('add_uuid_to_filament_form_user')
             ->hasConfigFile('filament-form-builder')
             ->hasRoute('routes')
             ->hasViews('filament-form-builder');

--- a/src/Models/FilamentForm.php
+++ b/src/Models/FilamentForm.php
@@ -18,11 +18,28 @@ class FilamentForm extends Model
 {
     use HasFactory;
 
+    protected $primaryKey = 'uuid';
+
+    protected $keyType = 'string';
+
+    protected $table = 'filament_forms';
+
     protected $guarded = [];
 
     protected $casts = [
         'permit_guest_entries' => 'boolean',
     ];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (empty($model->uuid)) {
+                $model->uuid = Str::uuid()->toString();
+            }
+        });
+    }
 
     public function users(): BelongsToMany
     {
@@ -31,17 +48,17 @@ class FilamentForm extends Model
 
     public function filamentFormFields(): HasMany
     {
-        return $this->hasMany(FilamentFormField::class)
+        return $this->hasMany(FilamentFormField::class, 'filament_form_id', 'id')
             ->orderBy('order', 'asc');
     }
 
     public function filamentFormUsers(): HasMany
     {
-        return $this->hasMany(FilamentFormUser::class);
+        return $this->hasMany(FilamentFormUser::class, 'filament_form_id', 'id');
     }
 
     public function getFormLinkAttribute(): string
     {
-        return route(config('filament-form-builder.filament-form-show-route'), $this->id);
+        return route(config('filament-form-builder.filament-form-show-route'), $this->uuid);
     }
 }

--- a/src/Models/FilamentFormField.php
+++ b/src/Models/FilamentFormField.php
@@ -39,6 +39,6 @@ class FilamentFormField extends Model implements Sortable
 
     public function filamentForm(): BelongsTo
     {
-        return $this->belongsTo(FilamentForm::class);
+        return $this->belongsTo(FilamentForm::class, 'filament_form_id', 'id');
     }
 }

--- a/src/Models/FilamentFormUser.php
+++ b/src/Models/FilamentFormUser.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\Str;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 
@@ -19,6 +20,10 @@ class FilamentFormUser extends Model implements HasMedia
     use HasFactory;
     use InteractsWithMedia;
 
+    protected $primaryKey = 'uuid';
+
+    protected $keyType = 'string';
+
     protected $table = 'filament_form_user';
 
     protected $guarded = [];
@@ -27,6 +32,17 @@ class FilamentFormUser extends Model implements HasMedia
         'entry' => 'json',
     ];
 
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (empty($model->uuid)) {
+                $model->uuid = Str::uuid()->toString();
+            }
+        });
+    }
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(config('auth.providers.users.model', Authenticatable::class));
@@ -34,7 +50,7 @@ class FilamentFormUser extends Model implements HasMedia
 
     public function filamentForm(): BelongsTo
     {
-        return $this->belongsTo(FilamentForm::class);
+        return $this->belongsTo(FilamentForm::class, 'id', 'id');
     }
 
     public function getKeyValueEntryAttribute()


### PR DESCRIPTION
# Details

I noticed that form entries, even those not intended for public access, were always visible. I had a use case where the form needed to be public, and UUIDs needed to be added to ensure that entries couldn't be easily accessed.

This PR introduces UUIDs to both FilamentForm and FilamentFormUser.

This was a quick fix and there may be other ways to solve it, but it worked for my situation. Feel free to accept or decline it as needed ;)