### PR TITLE
Make hard coded strings translatable

### DIFF
--- a/src/Enums/FilamentFieldTypeEnum.php
+++ b/src/Enums/FilamentFieldTypeEnum.php
@@ -42,22 +42,22 @@ enum FilamentFieldTypeEnum implements HasLabel
     public function fieldName(): string
     {
         return match ($this) {
-            self::TEXT => 'Text Input',
-            self::TEXTAREA => 'Textarea',
-            self::SELECT => 'Select',
-            self::SELECT_MULTIPLE => 'Select Multiple',
-            self::RICH_EDITOR => 'Rich Editor',
-            self::TOGGLE => 'Toggle',
-            self::CHECKBOX => 'Checkbox',
-            self::RADIO => 'Radio',
-            self::DATE_TIME_PICKER => 'DateTime Picker',
-            self::DATE_PICKER => 'Date Picker',
-            self::TIME_PICKER => 'Time Picker',
-            self::MARKDOWN_EDITOR => 'Markdown Editor',
-            self::COLOR_PICKER => 'Color Picker',
-            self::FILE_UPLOAD => 'File Upload',
-            self::REPEATER => 'Repeater',
-            self::HEADING => 'Heading',
+            self::TEXT => __('Text Input'),
+            self::TEXTAREA => __('Textarea'),
+            self::SELECT => __('Select'),
+            self::SELECT_MULTIPLE => __('Select Multiple'),
+            self::RICH_EDITOR => __('Rich Editor'),
+            self::TOGGLE => __('Toggle'),
+            self::CHECKBOX => __('Checkbox'),
+            self::RADIO => __('Radio'),
+            self::DATE_TIME_PICKER => __('DateTime Picker'),
+            self::DATE_PICKER => __('Date Picker'),
+            self::TIME_PICKER => __('Time Picker'),
+            self::MARKDOWN_EDITOR => __('Markdown Editor'),
+            self::COLOR_PICKER => __('Color Picker'),
+            self::FILE_UPLOAD => __('File Upload'),
+            self::REPEATER => __('Repeater'),
+            self::HEADING => __('Heading'),
         };
     }
 

--- a/src/Exports/FilamentFormUsersExport.php
+++ b/src/Exports/FilamentFormUsersExport.php
@@ -31,7 +31,7 @@ class FilamentFormUsersExport implements FromCollection, WithHeadings, WithMappi
     public function map($entry): array
     {
         $mapping = [
-            $entry->user->name ?? 'Guest',
+            $entry->user->name ?? __('Guest'),
             $entry->created_at,
             $entry->updated_at,
         ];

--- a/src/Filament/Resources/FilamentFormResource.php
+++ b/src/Filament/Resources/FilamentFormResource.php
@@ -31,12 +31,12 @@ class FilamentFormResource extends Resource
 
     public static function getBreadcrumb(): string
     {
-        return config('filament-form-builder.admin-panel-resource-name-plural');
+        return __(config('filament-form-builder.admin-panel-resource-name-plural'));
     }
 
     public static function getNavigationGroup(): ?string
     {
-        return config('filament-form-builder.admin-panel-group-name');
+        return __(config('filament-form-builder.admin-panel-group-name'));
     }
 
     public static function getNavigationIcon(): ?string
@@ -46,7 +46,7 @@ class FilamentFormResource extends Resource
 
     public static function getNavigationLabel(): string
     {
-        return config('filament-form-builder.admin-panel-resource-name-plural');
+        return __(config('filament-form-builder.admin-panel-resource-name-plural'));
     }
 
     public static function getNavigationSort(): ?int
@@ -59,13 +59,17 @@ class FilamentFormResource extends Resource
         return $form
             ->schema([
                 Forms\Components\TextInput::make('name')
+                    ->label(__('Name'))
                     ->required()
                     ->maxLength(255),
                 Toggle::make('permit_guest_entries')
-                    ->hint('Permit non registered users to submit this form'),
+                    ->label(__('Permit Guest Entries'))
+                    ->hint(__('Permit non registered users to submit this form')),
                 Forms\Components\TextInput::make('redirect_url')
-                    ->hint('(optional) complete this field to provide a custom redirect url on form completion. Use a fully qualified URL including "https://" to redirect to an external link, otherwise url will be relative to this sites domain'),
+                    ->label(__('Redirect URL'))
+                    ->hint(__('(optional) complete this field to provide a custom redirect url on form completion. Use a fully qualified URL including "https://" to redirect to an external link, otherwise url will be relative to this sites domain.')),
                 Forms\Components\Textarea::make('description')
+                    ->label(__('Description'))
                     ->columnSpanFull(),
             ]);
     }
@@ -75,27 +79,33 @@ class FilamentFormResource extends Resource
         return $table
             ->columns([
                 TextColumn::make('created_at')
+                    ->label(__('Created At'))
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('updated_at')
+                    ->label(__('Updated At'))
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('name')
+                    ->label(__('Name'))
                     ->sortable()
                     ->searchable(),
                 TextColumn::make('form_link')
+                    ->label(__('Form Link'))
                     ->copyable()
-                    ->copyMessage('Form link copied to clipboard')
+                    ->copyMessage(__('Form link copied to clipboard'))
                     ->copyMessageDuration(1500),
                 IconColumn::make('permit_guest_entries')
+                    ->label(__('Permit Guest Entries'))
                     ->sortable()
                     ->getStateUsing(function ($record) {
                         return (bool) $record->permit_guest_entries;
                     })
                     ->boolean(),
                 IconColumn::make('locked')
+                    ->label(__('Locked'))
                     ->sortable()
                     ->boolean(),
             ])
@@ -105,13 +115,15 @@ class FilamentFormResource extends Resource
             ->actions([
                 EditAction::make(),
                 Action::make('preview')
+                    ->label(__('Preview'))
                     ->visible(fn () => (bool) config('filament-form-builder.preview-route'))
                     ->url(fn ($record) => route(config('filament-form-builder.preview-route'), ['form' => $record->id]))
                     ->openUrlInNewTab(),
                 Action::make('copy')
+                    ->label(__('Copy'))
                     ->action(function ($record) {
                         $formCopy = FilamentForm::create([
-                            'name' => $record->name.' - (Copy)',
+                            'name' => $record->name.' - ('.__('Copy').')',
                             'permit_guest_entries' => $record->permit_guest_entries,
                             'redirect_url' => $record->redirect_url,
                             'description' => $record->description,
@@ -131,8 +143,8 @@ class FilamentFormResource extends Resource
                         });
 
                         Notification::make()
-                            ->title('Form copied successfully')
-                            ->body('Please change the name of the form to something unique and remove the "(Copy)" suffix')
+                            ->title(__('Form copied successfully'))
+                            ->body(__('Please change the name of the form to something unique and remove the "(Copy)" suffix'))
                             ->success()
                             ->send();
 
@@ -144,7 +156,7 @@ class FilamentFormResource extends Resource
                     DeleteBulkAction::make(),
                 ]),
             ])
-            ->emptyStateHeading('No '.config('filament-form-builder.admin-panel-resource-name-plural'));
+            ->emptyStateHeading(__('No').' '.config('filament-form-builder.admin-panel-resource-name-plural'));
     }
 
     public static function getRelations(): array

--- a/src/Filament/Resources/FilamentFormResource/Pages/CreateFilamentForm.php
+++ b/src/Filament/Resources/FilamentFormResource/Pages/CreateFilamentForm.php
@@ -11,6 +11,6 @@ class CreateFilamentForm extends CreateRecord
 
     public function getTitle(): string
     {
-        return 'Create '.config('filament-form-builder.admin-panel-resource-name');
+        return __('Create').' '.__(config('filament-form-builder.admin-panel-resource-name'));
     }
 }

--- a/src/Filament/Resources/FilamentFormResource/Pages/EditFilamentForm.php
+++ b/src/Filament/Resources/FilamentFormResource/Pages/EditFilamentForm.php
@@ -12,7 +12,7 @@ class EditFilamentForm extends EditRecord
 
     public function getTitle(): string
     {
-        return 'Edit '.config('filament-form-builder.admin-panel-resource-name');
+        return __('Edit').' '.__(config('filament-form-builder.admin-panel-resource-name'));
     }
 
     protected function getHeaderActions(): array
@@ -20,6 +20,7 @@ class EditFilamentForm extends EditRecord
         return [
             Actions\DeleteAction::make(),
             Actions\Action::make('preview')
+                ->label(__('Preview'))
                 ->visible(fn () => (bool) config('filament-form-builder.preview-route'))
                 ->url(fn ($record) => route(config('filament-form-builder.preview-route'), ['form' => $record->id]))
                 ->openUrlInNewTab(),

--- a/src/Filament/Resources/FilamentFormResource/Pages/ListFilamentForms.php
+++ b/src/Filament/Resources/FilamentFormResource/Pages/ListFilamentForms.php
@@ -12,14 +12,14 @@ class ListFilamentForms extends ListRecords
 
     public function getTitle(): string
     {
-        return config('filament-form-builder.admin-panel-resource-name-plural');
+        return __(config('filament-form-builder.admin-panel-resource-name-plural'));
     }
 
     protected function getHeaderActions(): array
     {
         return [
             Actions\CreateAction::make()
-                ->label('Create '.config('filament-form-builder.admin-panel-resource-name')),
+                ->label(__('Create').' '.__(config('filament-form-builder.admin-panel-resource-name'))),
         ];
     }
 }

--- a/src/Filament/Resources/FilamentFormResource/RelationManagers/FilamentFormFieldsRelationManager.php
+++ b/src/Filament/Resources/FilamentFormResource/RelationManagers/FilamentFormFieldsRelationManager.php
@@ -33,6 +33,7 @@ class FilamentFormFieldsRelationManager extends RelationManager
         return $form
             ->schema([
                 Select::make('type')
+                    ->label(__('Type'))
                     ->options(function () {
                         return collect(FilamentFieldTypeEnum::cases())
                             ->mapWithKeys(fn ($type) => [$type->name => $type->fieldName()])
@@ -42,14 +43,16 @@ class FilamentFormFieldsRelationManager extends RelationManager
                     ->required()
                     ->live(),
                 TextInput::make('label')
+                    ->label(__('Label'))
                     ->required()
                     ->maxLength(255)
                     ->label(function (Get $get) {
-                        return $get('type') === FilamentFieldTypeEnum::HEADING->name ? 'Heading' : 'Label';
+                        return $get('type') === FilamentFieldTypeEnum::HEADING->name ? __('Heading') : __('Label');
                     }),
                 TagsInput::make('options')
-                    ->placeholder('Add options')
-                    ->hint('Press enter after inputting each option')
+                    ->label(__('Options'))
+                    ->placeholder(__('Add options'))
+                    ->hint(__('Press enter after inputting each option'))
                     ->visible(function (Get $get) {
                         if ($get('type')) {
                             return FilamentFieldTypeEnum::fromString($get('type'))->hasOptions();
@@ -59,32 +62,37 @@ class FilamentFormFieldsRelationManager extends RelationManager
                     }),
                 Textarea::make('hint')
                     ->label(function (Get $get) {
-                        return $get('type') === FilamentFieldTypeEnum::HEADING->name ? 'Subheading' : 'Hint';
+                        return $get('type') === FilamentFieldTypeEnum::HEADING->name ? __('Subheading') : __('Hint');
                     }),
                 TagsInput::make('rules')
-                    ->placeholder('Add rules')
-                    ->hint('view list of available rules here, https://laravel.com/docs/11.x/validation#available-validation-rules')
+                    ->label(__('Rules'))
+                    ->placeholder(__('Add rules'))
+                    ->hint(__('view list of available rules here, https://laravel.com/docs/11.x/validation#available-validation-rules'))
                     ->visible(function (Get $get) {
                         return $get('type') !== FilamentFieldTypeEnum::REPEATER->name
                             && $get('type') !== FilamentFieldTypeEnum::HEADING->name;
                     }),
                 TextInput::make('order')
+                    ->label(__('Order'))
                     ->default(function () {
                         return $this->getOwnerRecord()->filamentFormFields()->count() + 1;
                     })
                     ->numeric(),
                 Toggle::make('required')
+                    ->label(__('Required'))
                     ->visible(function (Get $get) {
                         return $get('type') !== FilamentFieldTypeEnum::REPEATER->name
                             && $get('type') !== FilamentFieldTypeEnum::HEADING->name;
                     }),
                 Repeater::make('schema')
-                    ->label('Fields')
+                    ->label(__('Fields'))
                     ->schema([
                         TextInput::make('label')
+                            ->label(__('Label'))
                             ->required()
                             ->maxLength(255),
                         Select::make('type')
+                            ->label(__('Type'))
                             ->options(function () {
                                 $options = collect(FilamentFieldTypeEnum::cases())
                                     ->filter(fn ($type) => $type !== FilamentFieldTypeEnum::REPEATER)
@@ -96,8 +104,9 @@ class FilamentFormFieldsRelationManager extends RelationManager
                             ->required()
                             ->live(),
                         TagsInput::make('options')
-                            ->placeholder('Add options')
-                            ->hint('Press enter after inputting each option')
+                            ->label(__('Options'))
+                            ->placeholder(__('Add options'))
+                            ->hint(__('Press enter after inputting each option'))
                             ->visible(function (Get $get) {
                                 if ($get('type')) {
                                     return FilamentFieldTypeEnum::fromString($get('type'))->hasOptions();
@@ -105,11 +114,12 @@ class FilamentFormFieldsRelationManager extends RelationManager
 
                                 return false;
                             }),
-                        Textarea::make('hint'),
+                        Textarea::make('hint')->label(__('Hint')),
                         TagsInput::make('rules')
-                            ->placeholder('Add rules')
-                            ->hint('view list of available rules here, https://laravel.com/docs/11.x/validation#available-validation-rules'),
-                        Toggle::make('required'),
+                            ->label(__('Rules'))
+                            ->placeholder(__('Add rules'))
+                            ->hint(__('view list of available rules here, https://laravel.com/docs/11.x/validation#available-validation-rules')),
+                        Toggle::make('required')->label(__('Required')),
                     ])
                     ->columns(2)
                     ->columnSpanFull()
@@ -125,19 +135,22 @@ class FilamentFormFieldsRelationManager extends RelationManager
 
         return $table
             ->recordTitleAttribute('label')
-            ->heading(config('filament-form-builder.admin-panel-filament-form-field-name-plural'))
-            ->modelLabel(config('filament-form-builder.admin-panel-filament-form-field-name'))
+            ->heading(__(config('filament-form-builder.admin-panel-filament-form-field-name-plural')))
+            ->modelLabel(__(config('filament-form-builder.admin-panel-filament-form-field-name')))
             ->reorderable('order')
             ->columns([
-                TextColumn::make('label'),
+                TextColumn::make('label')->label(__('Label')),
                 TextColumn::make('order')
+                    ->label(__('Order'))
                     ->numeric()
                     ->sortable(),
                 TextColumn::make('type')
+                    ->label(__('Type'))
                     ->formatStateUsing(function ($record) {
                         return $record->type->fieldName();
                     }),
                 IconColumn::make('required')
+                    ->label(__('Required'))
                     ->sortable()
                     ->getStateUsing(function ($record) {
                         return (bool) $record->required;
@@ -149,10 +162,11 @@ class FilamentFormFieldsRelationManager extends RelationManager
                     ->visible(function () use ($form) {
                         return ! $form->locked;
                     })
-                    ->label('Create Field'),
+                    ->label(__('Create Field')),
                 Action::make('lock_fields')
+                    ->label(__('Lock fields'))
                     ->requiresConfirmation()
-                    ->modalHeading('Lock Form Fields. Doing this will lock the forms fields and new fields will no longer be able to be changed or edited')
+                    ->modalHeading(__('Lock Form Fields. Doing this will lock the forms fields and new fields will no longer be able to be changed or edited.'))
                     ->visible(function () use ($form) {
                         return ! $form->locked;
                     })
@@ -162,8 +176,9 @@ class FilamentFormFieldsRelationManager extends RelationManager
                         ]);
                     }),
                 Action::make('unlock_fields')
+                    ->label(__('Unlock fields'))
                     ->requiresConfirmation()
-                    ->modalHeading('Unlock Form Fields. Changing fields after entries has been made can cause inconsistencies for prexisting entries')
+                    ->modalHeading(__('Unlock Form Fields. Changing fields after entries has been made can cause inconsistencies for preexisting entries.'))
                     ->visible(function () use ($form) {
                         return $form->locked;
                     })

--- a/src/Filament/Resources/FilamentFormResource/RelationManagers/FilamentFormUsersRelationManager.php
+++ b/src/Filament/Resources/FilamentFormResource/RelationManagers/FilamentFormUsersRelationManager.php
@@ -26,7 +26,7 @@ class FilamentFormUsersRelationManager extends RelationManager
 
     public static function getLabel(): string
     {
-        return 'Custom Posts Title';
+        return __('Custom Posts Title');
     }
 
     public function form(Form $form): Form
@@ -43,21 +43,25 @@ class FilamentFormUsersRelationManager extends RelationManager
     {
         return $table
             ->recordTitleAttribute('user.name')
-            ->heading(config('filament-form-builder.admin-panel-filament-form-user-name-plural'))
+            ->heading(__(config('filament-form-builder.admin-panel-filament-form-user-name-plural')))
             ->columns([
                 Tables\Columns\TextColumn::make('user.name')
                     ->sortable()
                     ->searchable(),
                 Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('Created At'))
                     ->sortable(),
                 Tables\Columns\TextColumn::make('updated_at')
+                    ->label(__('Updated At'))
                     ->sortable(),
             ])
             ->recordUrl(fn ($record) => route(config('filament-form-builder.filament-form-user-show-route'), $record))
             ->filters([
                 Filter::make('guest_entries')
+                    ->label(__('Guest Entries'))
                     ->query(fn (Builder $query): Builder => $query->whereNull('user_id')),
                 Filter::make('user_entries')
+                    ->label(__('User Entries'))
                     ->query(fn (Builder $query): Builder => $query->whereNotNull('user_id')),
             ])
             ->headerActions([
@@ -68,7 +72,7 @@ class FilamentFormUsersRelationManager extends RelationManager
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
                     Tables\Actions\DeleteBulkAction::make(),
-                    BulkAction::make('Export Selected')
+                    BulkAction::make(__('Export Selected'))
                         ->action(fn (Collection $records) => Excel::download(
                             new FilamentFormUsersExport($records),
                             urlencode($this->getOwnerRecord()->name).'_form_entry_export'.now()->format('Y-m-dhis').'.csv')

--- a/src/Livewire/FilamentFormUser/Show.php
+++ b/src/Livewire/FilamentFormUser/Show.php
@@ -32,21 +32,21 @@ class Show extends Component implements HasForms, HasInfolists
             ->schema([
                 TextEntry::make('user.name'),
                 TextEntry::make('filamentForm.name')
-                    ->label('Form Name'),
+                    ->label(__('Form Name')),
                 TextEntry::make('created_at')
-                    ->label('Form Completed At')
+                    ->label(__('Form Completed At'))
                     ->dateTime(),
                 KeyValueEntry::make('key_value_entry')
-                    ->label('Form Entry')
-                    ->keyLabel('Question')
-                    ->valueLabel('Answer'),
+                    ->label(__('Form Entry'))
+                    ->keyLabel(__('Question'))
+                    ->valueLabel(__('Answer')),
                 \Filament\Infolists\Components\RepeatableEntry::make('media')
-                    ->label('Uploaded Files')
+                    ->label(__('Uploaded Files'))
                     ->schema([
                         TextEntry::make('custom_properties.field_label')
-                            ->label('Question'),
+                            ->label(__('Question')),
                         TextEntry::make('custom_properties.original_name')
-                            ->label('File Name')
+                            ->label(__('File Name'))
                             ->suffixAction(
                                 InfolistAction::make('download')
                                     ->icon('heroicon-o-arrow-down-tray')


### PR DESCRIPTION
# Details

Make hard coded strings translatable and fix one spelling error. No translations included.