### PR TITLE
Add default policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,36 @@ You can disable the redirect when including the Form/Show component inside of an
     @livewire('tapp.filament-form-builder.livewire.filament-form.show', ['form' => $test->form, 'blockRedirect' => true])
 ```
 
+### Security
+
+This package does not implement any access control for form entries by default. It is crucial that you secure your form entries in your application using policies or other authorization methods. For example:
+
+```php
+// In your application
+class FilamentFormUserPolicy
+{
+    public function view(User $user, FilamentFormUser $entry): bool
+    {
+        // Only allow users to view their own entries
+        return $user->id === $entry->user_id;
+    }
+
+    public function viewAny(User $user): bool
+    {
+        // Define who can list entries
+        return $user->can('view_form_entries');
+    }
+}
+```
+
+Register your policy in your application's `AuthServiceProvider`:
+
+```php
+protected $policies = [
+    \Tapp\FilamentFormBuilder\Models\FilamentFormUser::class => \App\Policies\FilamentFormUserPolicy::class,
+];
+```
+
 ### Events
 #### Livewire
 The FilamentForm/Show component emits an 'entrySaved' event when a form entry is saved. You can handle this event in a parent component to as follows.

--- a/resources/views/livewire/filament-form/show.blade.php
+++ b/resources/views/livewire/filament-form/show.blade.php
@@ -1,20 +1,24 @@
 <div class="flex flex-row justify-center p-16 fb-form-component filament-form-builder">
     <div class="max-w-[600px] min-w-[400px] rounded-xl border-2 p-4 fb-form-container">
-        <h1 class="mb-2 text-xl font-bold">
-            {{ $this->filamentForm->name }}
-        </h1>
-        <p class="mb-4">
-            {{ $this->filamentForm->description }}
-        </p>
-        <form wire:submit="create">
-            @csrf
-            {{ $this->form }}
+        @if($showGuestEntry)
+            <livewire:filament-form-user.show :entry="$guestEntry" />
+        @else
+            <h1 class="mb-2 text-xl font-bold">
+                {{ $this->filamentForm->name }}
+            </h1>
+            <p class="mb-4">
+                {{ $this->filamentForm->description }}
+            </p>
+            <form wire:submit="create">
+                @csrf
+                {{ $this->form }}
 
-            <x-filament::button type="submit" class="mt-6">
-                Submit
-            </x-filament::button>
-        </form>
+                <x-filament::button type="submit" class="mt-6">
+                    Submit
+                </x-filament::button>
+            </form>
 
-        <x-filament-actions::modals />
+            <x-filament-actions::modals />
+        @endif
     </div>
 </div>

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -6,7 +6,7 @@ use Tapp\FilamentFormBuilder\Livewire\FilamentFormUser\Entry as FilamentFormUser
 use Tapp\FilamentFormBuilder\Middleware\CheckFormGuestAccess;
 
 Route::get(config('filament-form-builder.filament-form-user-uri').'/{entry}', FilamentFormUserEntry::class)
-    ->middleware('web')
+    ->middleware('auth')
     ->name('filament-form-users.show');
 
 Route::get(config('filament-form-builder.filament-form-uri').'/{form}', FilamentForm::class)

--- a/src/Livewire/FilamentForm/Show.php
+++ b/src/Livewire/FilamentForm/Show.php
@@ -31,6 +31,7 @@ class Show extends Component implements HasForms
     public bool $preview;
 
     public ?FilamentFormUser $guestEntry = null;
+
     public bool $showGuestEntry = false;
 
     public ?array $data = [];


### PR DESCRIPTION
# Details

Resolves an issue where unauthenticated users were allowed to view the form entries while still allowing guests to view their submitted form. Adds a notice to the readme instructing users to create their own policies for securing the models associated with this package.