### PR TITLE
Options with quotes fix

### DIFF
--- a/src/Livewire/FilamentForm/Show.php
+++ b/src/Livewire/FilamentForm/Show.php
@@ -304,7 +304,6 @@ class Show extends Component implements HasForms
         return implode(', ', $valuesArray);
     }
 
-
     public function render()
     {
         /** @phpstan-ignore-next-line */

--- a/src/Livewire/FilamentForm/Show.php
+++ b/src/Livewire/FilamentForm/Show.php
@@ -63,7 +63,6 @@ class Show extends Component implements HasForms
             if ($fieldData->type === FilamentFieldTypeEnum::SELECT_MULTIPLE) {
                 $filamentField = $filamentField
                     ->multiple()
-                    // !!! remove this before deploy
                     ->live()
                     ->required()
                     ->default([]);
@@ -130,7 +129,7 @@ class Show extends Component implements HasForms
 
         if (isset($fieldData['options'])) {
             $filamentField = $filamentField
-                ->options(array_combine($fieldData['options'], $fieldData['options']));
+                ->options($fieldData['options']);
         }
 
         if (isset($fieldData['hint'])) {
@@ -284,9 +283,9 @@ class Show extends Component implements HasForms
         $valueData = '';
 
         if ($field->type->hasOptions() && is_array($value)) {
-            $valueData = implode(', ', $value);
+            $valueData = $this->extractMultiSelectValue($value, $field->options);
         } elseif ($field->type->hasOptions() && ! is_array($value)) {
-            $valueData = $value;
+            $valueData = $field->options[$value];
         } elseif ($field->type->isBool()) {
             $valueData = (bool) $value ? 'true' : 'false';
         } else {
@@ -295,6 +294,16 @@ class Show extends Component implements HasForms
 
         return $valueData;
     }
+
+    public static function extractMultiSelectValue(array $value, array $options): string
+    {
+        $valuesArray = array_map(function ($value) use ($options) {
+            return $options[$value];
+        }, $value);
+
+        return implode(', ', $valuesArray);
+    }
+
 
     public function render()
     {


### PR DESCRIPTION
# Details
This PR resolves an issue introduced with the Filament v4 upgrade that was causing the value of options with quotes in them to be set to '/' in the html markup rendered by filament. This was causing these options to fail validation. I have refactored the handling of select values to use keys instead of values which are then used to look up the corresponding value when the form entry is saved, retaining backwards compatibility.

# Steps to Test
1. Create a new form with a select and and a multi select field
2. add an option to both featuring quotation marks such as, 'an "option'.
3. test filling out form while selecting this option in both fields.
4. form should pass validation and values should be saved correctly to the filament_form_user
