### PR TITLE
Restrict copy action to users who can create forms

### DIFF
--- a/src/Filament/Resources/FilamentFormResource.php
+++ b/src/Filament/Resources/FilamentFormResource.php
@@ -141,6 +141,8 @@ class FilamentFormResource extends Resource
                     ->url(fn ($record) => route(config('filament-form-builder.preview-route'), ['form' => $record->id]))
                     ->openUrlInNewTab(),
                 Action::make('copy')
+                    ->visible(fn (): bool => static::canCreate())
+                    ->authorize(fn (): bool => static::canCreate())
                     ->action(function ($record) {
                         $formCopy = FilamentForm::create([
                             'name' => $record->name.' - (Copy)',


### PR DESCRIPTION
## Summary
- Copy table action now uses `visible(canCreate())` and `authorize(canCreate())` so only users who can create forms see and run the copy action.
- Prevents read-only users (e.g. Staff role) from copying forms, which is equivalent to create.

Made with [Cursor](https://cursor.com)