### PR TITLE
Table actions in ActionGroup at row start

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "tapp/filament-form-builder",
-    "version": "4.1.0",
     "description": "User facing form builder using Filament components",
     "keywords": [
         "tapp network",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "tapp/filament-form-builder",
+    "version": "4.1.0",
     "description": "User facing form builder using Filament components",
     "keywords": [
         "tapp network",

--- a/src/Filament/Resources/FilamentFormResource.php
+++ b/src/Filament/Resources/FilamentFormResource.php
@@ -3,6 +3,7 @@
 namespace Tapp\FilamentFormBuilder\Filament\Resources;
 
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -18,6 +19,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Support\Facades\Redirect;
 use Tapp\FilamentFormBuilder\Filament\Resources\FilamentFormResource\Pages\CreateFilamentForm;
@@ -135,45 +137,47 @@ class FilamentFormResource extends Resource
                 //
             ])
             ->recordActions([
-                EditAction::make(),
-                Action::make('preview')
-                    ->visible(fn () => (bool) config('filament-form-builder.preview-route'))
-                    ->url(fn ($record) => route(config('filament-form-builder.preview-route'), ['form' => $record->id]))
-                    ->openUrlInNewTab(),
-                Action::make('copy')
-                    ->visible(fn (): bool => static::canCreate())
-                    ->authorize(fn (): bool => static::canCreate())
-                    ->action(function ($record) {
-                        $formCopy = FilamentForm::create([
-                            'name' => $record->name.' - (Copy)',
-                            'permit_guest_entries' => $record->permit_guest_entries,
-                            'redirect_url' => $record->redirect_url,
-                            'description' => $record->description,
-                            'notification_emails' => $record->notification_emails,
-                        ]);
-
-                        $record->filamentFormFields->each(function ($field) use ($formCopy) {
-                            FilamentFormField::create([
-                                'filament_form_id' => $formCopy->id,
-                                'label' => $field->label,
-                                'type' => $field->type,
-                                'required' => $field->required,
-                                'order' => $field->order,
-                                'hint' => $field->hint,
-                                'options' => $field->options,
-                                'rules' => $field->rules,
+                ActionGroup::make([
+                    EditAction::make(),
+                    Action::make('preview')
+                        ->visible(fn () => (bool) config('filament-form-builder.preview-route'))
+                        ->url(fn ($record) => route(config('filament-form-builder.preview-route'), ['form' => $record->id]))
+                        ->openUrlInNewTab(),
+                    Action::make('copy')
+                        ->visible(fn (): bool => static::canCreate())
+                        ->authorize(fn (): bool => static::canCreate())
+                        ->action(function ($record) {
+                            $formCopy = FilamentForm::create([
+                                'name' => $record->name.' - (Copy)',
+                                'permit_guest_entries' => $record->permit_guest_entries,
+                                'redirect_url' => $record->redirect_url,
+                                'description' => $record->description,
+                                'notification_emails' => $record->notification_emails,
                             ]);
-                        });
 
-                        Notification::make()
-                            ->title('Form copied successfully')
-                            ->body('Please change the name of the form to something unique and remove the "(Copy)" suffix')
-                            ->success()
-                            ->send();
+                            $record->filamentFormFields->each(function ($field) use ($formCopy) {
+                                FilamentFormField::create([
+                                    'filament_form_id' => $formCopy->id,
+                                    'label' => $field->label,
+                                    'type' => $field->type,
+                                    'required' => $field->required,
+                                    'order' => $field->order,
+                                    'hint' => $field->hint,
+                                    'options' => $field->options,
+                                    'rules' => $field->rules,
+                                ]);
+                            });
 
-                        return Redirect::to('/admin/filament-forms/'.$formCopy->id.'/edit');
-                    }),
-            ])
+                            Notification::make()
+                                ->title('Form copied successfully')
+                                ->body('Please change the name of the form to something unique and remove the "(Copy)" suffix')
+                                ->success()
+                                ->send();
+
+                            return Redirect::to('/admin/filament-forms/'.$formCopy->id.'/edit');
+                        }),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),

--- a/src/Filament/Resources/FilamentFormResource/RelationManagers/FilamentFormFieldsRelationManager.php
+++ b/src/Filament/Resources/FilamentFormResource/RelationManagers/FilamentFormFieldsRelationManager.php
@@ -3,6 +3,7 @@
 namespace Tapp\FilamentFormBuilder\Filament\Resources\FilamentFormResource\RelationManagers;
 
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
@@ -19,6 +20,7 @@ use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Tapp\FilamentFormBuilder\Enums\FilamentFieldTypeEnum;
@@ -183,15 +185,17 @@ class FilamentFormFieldsRelationManager extends RelationManager
                     }),
             ])
             ->recordActions([
-                EditAction::make()
-                    ->visible(function () use ($form) {
-                        return ! $form->locked;
-                    }),
-                DeleteAction::make()
-                    ->visible(function () use ($form) {
-                        return ! $form->locked;
-                    }),
-            ])
+                ActionGroup::make([
+                    EditAction::make()
+                        ->visible(function () use ($form) {
+                            return ! $form->locked;
+                        }),
+                    DeleteAction::make()
+                        ->visible(function () use ($form) {
+                            return ! $form->locked;
+                        }),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make()

--- a/src/Filament/Resources/FilamentFormResource/RelationManagers/FilamentFormUsersRelationManager.php
+++ b/src/Filament/Resources/FilamentFormResource/RelationManagers/FilamentFormUsersRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentFormBuilder\Filament\Resources\FilamentFormResource\RelationManagers;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkAction;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
@@ -10,6 +11,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -66,8 +68,10 @@ class FilamentFormUsersRelationManager extends RelationManager
             ->headerActions([
             ])
             ->recordActions([
-                DeleteAction::make(),
-            ])
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),


### PR DESCRIPTION
Puts all admin table row actions in a single ActionGroup and positions them at row start (BeforeColumns).

- FilamentFormResource
- FilamentFormFieldsRelationManager
- FilamentFormUsersRelationManager
- composer.json: add version for path repo installs

Made with [Cursor](https://cursor.com)