### PR TITLE
Add private entries support for form entry visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ Key configuration options include:
 
 See `config/filament-form-builder.php` for all available configuration options.
 
+### Private entries
+
+You can hide form entries on a per-form basis. When **Private entries** is enabled for a form, only users allowed by your application (e.g. via a [Laravel gate](https://laravel.com/docs/authorization#gates)) can view or export those entries.
+
+- **Per form**: Each form has a **Private entries** toggle (next to "Permit guest entries"). When enabled, the Entries tab and export actions are restricted to users who pass your gate.
+- **Gate**: Your application defines a gate (e.g. `viewPrivateFormEntries`). The package does not register it—you decide who can view private entries (e.g. Admins only). Call the gate from your **policy** when the form has `private_entries`.
+- **Integration**: In your `FilamentFormUser` policy `view()` method, when `$entry->filamentForm->private_entries` is true, return `Gate::allows('viewPrivateFormEntries', $entry->filamentForm)`. Optionally add a `viewEntries()` method on your `FilamentForm` policy and use it in an extended relation manager so the Entries tab and Export Selected visibility respect the same logic.
+
 ### Configuring Tailwind:
 
 Add this to your tailwind.config.js content section:

--- a/README.md
+++ b/README.md
@@ -165,11 +165,43 @@ See `config/filament-form-builder.php` for all available configuration options.
 
 ### Private entries
 
-You can hide form entries on a per-form basis. When **Private entries** is enabled for a form, only users allowed by your application (e.g. via a [Laravel gate](https://laravel.com/docs/authorization#gates)) can view or export those entries.
+You can restrict who can view or export form entries on a per-form basis. When **Private entries** is enabled for a form, the package uses your application’s policy to decide visibility.
 
-- **Per form**: Each form has a **Private entries** toggle (next to "Permit guest entries"). When enabled, the Entries tab and export actions are restricted to users who pass your gate.
-- **Gate**: Your application defines a gate (e.g. `viewPrivateFormEntries`). The package does not register it—you decide who can view private entries (e.g. Admins only). Call the gate from your **policy** when the form has `private_entries`.
-- **Integration**: In your `FilamentFormUser` policy `view()` method, when `$entry->filamentForm->private_entries` is true, return `Gate::allows('viewPrivateFormEntries', $entry->filamentForm)`. Optionally add a `viewEntries()` method on your `FilamentForm` policy and use it in an extended relation manager so the Entries tab and Export Selected visibility respect the same logic.
+#### App setup (required for private entries)
+
+1. **Register a policy** for `Tapp\FilamentFormBuilder\Models\FilamentForm` (e.g. `FilamentFormPolicy`).
+
+2. **Implement `viewEntries`** on that policy with this **exact method name** and signature. Put all your logic here (e.g. “Admin only”); no gate is required:
+
+   ```php
+   // e.g. app/Policies/FilamentFormPolicy.php
+   public function viewEntries(User $user, FilamentForm $form): bool
+   {
+       if (! (bool) $form->private_entries) {
+           return true;
+       }
+       return $user->hasRole('Admin'); // or your own rules
+   }
+   ```
+
+   The package calls `$user->can('viewEntries', $ownerRecord)` when:
+
+   - Deciding whether to show the **Entries** relation manager for a form (edit page).
+   - Deciding whether to show the **Export Selected** bulk action.
+
+   If your policy does not define `viewEntries`, the package does not restrict the Entries tab or export (all users who can view the form see them).
+
+3. **Entry-level visibility**: In your `FilamentFormUser` policy `view()` method, when the entry’s form has `private_entries`, delegate to the same policy so individual entry view links are restricted:
+
+   ```php
+   if ($entry->filamentForm && (bool) $entry->filamentForm->private_entries) {
+       return $user->can('viewEntries', $entry->filamentForm);
+   }
+   ```
+
+4. **Form edit UI**: The **Private entries** toggle on the form is disabled when the form is private and the current user fails `viewEntries`, so they cannot turn the setting off to gain access.
+
+No gate and no extended relation manager are required—the package’s relation manager and resource use the policy when `viewEntries` is present.
 
 ### Configuring Tailwind:
 

--- a/database/migrations/add_private_entries_to_filament_forms_table.php.stub
+++ b/database/migrations/add_private_entries_to_filament_forms_table.php.stub
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('filament_forms', function (Blueprint $table): void {
+            $table->boolean('private_entries')->default(false)->after('permit_guest_entries');
+        });
+    }
+};

--- a/src/Filament/Resources/FilamentFormResource.php
+++ b/src/Filament/Resources/FilamentFormResource.php
@@ -21,6 +21,7 @@ use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Redirect;
 use Tapp\FilamentFormBuilder\Filament\Resources\FilamentFormResource\Pages\CreateFilamentForm;
 use Tapp\FilamentFormBuilder\Filament\Resources\FilamentFormResource\Pages\EditFilamentForm;
@@ -88,10 +89,16 @@ class FilamentFormResource extends Resource
                 TextInput::make('name')
                     ->required()
                     ->maxLength(255),
-                Toggle::make('permit_guest_entries')
-                    ->hint('Permit non registered users to submit this form'),
                 TextInput::make('redirect_url')
                     ->hint('(optional) complete this field to provide a custom redirect url on form completion. Use a fully qualified URL including "https://" to redirect to an external link, otherwise url will be relative to this sites domain'),
+                Toggle::make('permit_guest_entries')
+                    ->hint('Permit non registered users to submit this form'),
+                Toggle::make('private_entries')
+                    ->hint('When enabled, entries for this form can be restricted to certain users (e.g. via a gate in your application).')
+                    ->disabled(fn (?FilamentForm $record): bool => static::userCannotChangePrivateEntries($record))
+                    ->dehydrateStateUsing(fn ($state, ?FilamentForm $record): bool => static::userCannotChangePrivateEntries($record) && $record
+                        ? (bool) $record->private_entries
+                        : (bool) $state),
                 Textarea::make('description')
                     ->columnSpanFull(),
                 Section::make('Notifications')
@@ -129,6 +136,9 @@ class FilamentFormResource extends Resource
                         return (bool) $record->permit_guest_entries;
                     })
                     ->boolean(),
+                IconColumn::make('private_entries')
+                    ->sortable()
+                    ->boolean(),
                 IconColumn::make('locked')
                     ->sortable()
                     ->boolean(),
@@ -150,6 +160,7 @@ class FilamentFormResource extends Resource
                             $formCopy = FilamentForm::create([
                                 'name' => $record->name.' - (Copy)',
                                 'permit_guest_entries' => $record->permit_guest_entries,
+                                'private_entries' => $record->private_entries,
                                 'redirect_url' => $record->redirect_url,
                                 'description' => $record->description,
                                 'notification_emails' => $record->notification_emails,
@@ -201,6 +212,29 @@ class FilamentFormResource extends Resource
             'create' => CreateFilamentForm::route('/create'),
             'edit' => EditFilamentForm::route('/{record}/edit'),
         ];
+    }
+
+    /**
+     * True when the current user must not be allowed to change the private_entries toggle.
+     * Used when the form is private and the app's viewEntries policy denies the user.
+     */
+    protected static function userCannotChangePrivateEntries(?FilamentForm $record): bool
+    {
+        if (! $record || ! $record->exists || ! (bool) $record->private_entries) {
+            return false;
+        }
+
+        $user = Auth::user();
+        if (! $user) {
+            return true;
+        }
+
+        $policy = policy($record);
+        if ($policy && method_exists($policy, 'viewEntries')) {
+            return ! $user->can('viewEntries', $record);
+        }
+
+        return false;
     }
 
     protected static function getNotificationEmailsField(): Component

--- a/src/Filament/Resources/FilamentFormResource/RelationManagers/FilamentFormUsersRelationManager.php
+++ b/src/Filament/Resources/FilamentFormResource/RelationManagers/FilamentFormUsersRelationManager.php
@@ -41,10 +41,18 @@ class FilamentFormUsersRelationManager extends RelationManager
             return false;
         }
 
-        /** @var \Illuminate\Contracts\Auth\Access\Authorizable $user */
-        $policy = policy($ownerRecord);
+        return self::userCanViewEntriesForOwner($user, $ownerRecord);
+    }
+
+    /**
+     * Whether the given user can view/export entries for the given owner form.
+     * Uses the owner model's viewEntries policy when present.
+     */
+    protected static function userCanViewEntriesForOwner(\Illuminate\Contracts\Auth\Authenticatable&\Illuminate\Contracts\Auth\Access\Authorizable $user, Model $owner): bool
+    {
+        $policy = policy($owner);
         if ($policy && method_exists($policy, 'viewEntries')) {
-            return $user->can('viewEntries', $ownerRecord);
+            return $user->can('viewEntries', $owner);
         }
 
         return true;
@@ -119,18 +127,12 @@ class FilamentFormUsersRelationManager extends RelationManager
      */
     protected function canViewEntriesForOwner(): bool
     {
-        $owner = $this->getOwnerRecord();
         $user = Auth::user();
         if (! $user) {
             return false;
         }
 
-        /** @var \Illuminate\Contracts\Auth\Access\Authorizable $user */
-        $policy = policy($owner);
-        if ($policy && method_exists($policy, 'viewEntries')) {
-            return $user->can('viewEntries', $owner);
-        }
-
-        return true;
+        /** @var \Illuminate\Contracts\Auth\Authenticatable&\Illuminate\Contracts\Auth\Access\Authorizable $user */
+        return self::userCanViewEntriesForOwner($user, $this->getOwnerRecord());
     }
 }

--- a/src/Filament/Resources/FilamentFormResource/RelationManagers/FilamentFormUsersRelationManager.php
+++ b/src/Filament/Resources/FilamentFormResource/RelationManagers/FilamentFormUsersRelationManager.php
@@ -17,12 +17,38 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
 use Maatwebsite\Excel\Facades\Excel;
 use Tapp\FilamentFormBuilder\Exports\FilamentFormUsersExport;
 
 class FilamentFormUsersRelationManager extends RelationManager
 {
     protected static string $relationship = 'filamentFormUsers';
+
+    /**
+     * Apps may restrict visibility of the Entries relation manager per form by defining
+     * a viewEntries($user, $form) method on the FilamentForm (owner) policy. When present,
+     * that policy is used; otherwise the default (related model viewAny) applies.
+     */
+    public static function canViewForRecord(Model $ownerRecord, string $pageClass): bool
+    {
+        if (! parent::canViewForRecord($ownerRecord, $pageClass)) {
+            return false;
+        }
+
+        $user = Auth::user();
+        if (! $user) {
+            return false;
+        }
+
+        /** @var \Illuminate\Contracts\Auth\Access\Authorizable $user */
+        $policy = policy($ownerRecord);
+        if ($policy && method_exists($policy, 'viewEntries')) {
+            return $user->can('viewEntries', $ownerRecord);
+        }
+
+        return true;
+    }
 
     public static function getTitle(Model $ownerRecord, string $pageClass): string
     {
@@ -81,8 +107,30 @@ class FilamentFormUsersRelationManager extends RelationManager
                             urlencode($this->getOwnerRecord()->name).'_form_entry_export'.now()->format('Y-m-dhis').'.csv')
                         )
                         ->icon('heroicon-o-document-chart-bar')
-                        ->deselectRecordsAfterCompletion(),
+                        ->deselectRecordsAfterCompletion()
+                        ->visible(fn (): bool => $this->canViewEntriesForOwner()),
                 ]),
             ]);
+    }
+
+    /**
+     * Whether the current user can view/export entries for the owner form.
+     * Uses the owner model's viewEntries policy when present.
+     */
+    protected function canViewEntriesForOwner(): bool
+    {
+        $owner = $this->getOwnerRecord();
+        $user = Auth::user();
+        if (! $user) {
+            return false;
+        }
+
+        /** @var \Illuminate\Contracts\Auth\Access\Authorizable $user */
+        $policy = policy($owner);
+        if ($policy && method_exists($policy, 'viewEntries')) {
+            return $user->can('viewEntries', $owner);
+        }
+
+        return true;
     }
 }

--- a/src/FilamentFormBuilderServiceProvider.php
+++ b/src/FilamentFormBuilderServiceProvider.php
@@ -27,6 +27,7 @@ class FilamentFormBuilderServiceProvider extends PackageServiceProvider
             ->hasMigration('add_schema_to_filament_form_fields')
             ->hasMigration('add_notification_emails_to_filament_forms_table')
             ->hasMigration('change_label_to_text_in_filament_form_fields')
+            ->hasMigration('add_private_entries_to_filament_forms_table')
             ->hasConfigFile('filament-form-builder')
             ->hasViews('filament-form-builder');
     }

--- a/src/Models/FilamentForm.php
+++ b/src/Models/FilamentForm.php
@@ -15,6 +15,7 @@ use Tapp\FilamentFormBuilder\Models\Traits\BelongsToTenant;
  * @property string|null $description
  * @property string|null $redirect_url
  * @property bool $permit_guest_entries
+ * @property bool $private_entries
  * @property array<int, string>|null $notification_emails
  * @property-read string $form_link
  */
@@ -27,6 +28,7 @@ class FilamentForm extends Model
 
     protected $casts = [
         'permit_guest_entries' => 'boolean',
+        'private_entries' => 'boolean',
         'notification_emails' => 'array',
     ];
 


### PR DESCRIPTION
Adds optional per-form `private_entries` so apps can restrict who can view/export entries (e.g. via a gate/policy).

**Changes**
- Migration stub and model: `private_entries` on `filament_forms`
- `FilamentFormResource`: private_entries toggle (disabled when form is private and app `viewEntries` policy denies user), table column, copy action; `redirect_url` field before `permit_guest_entries`
- `FilamentFormUsersRelationManager`: `canViewForRecord` and Export visibility use owner `viewEntries` policy when present
- README: Private entries section

Made with [Cursor](https://cursor.com)