### PR TITLE
Allow form description to be rich text / HTML

### DIFF
--- a/resources/views/livewire/filament-form/show.blade.php
+++ b/resources/views/livewire/filament-form/show.blade.php
@@ -3,9 +3,12 @@
         <h1 class="mb-2 text-xl font-bold">
             {{ $this->filamentForm->name }}
         </h1>
-        <p class="mb-4">
-            {{ $this->filamentForm->description }}
-        </p>
+        @if ($this->filamentForm->description)
+            <div class="mb-4 prose prose-sm max-w-none dark:prose-invert">
+                {{-- Description is admin-controlled rich text (HTML) --}}
+                {!! $this->filamentForm->description !!}
+            </div>
+        @endif
         <form wire:submit="create">
             @csrf
             {{ $this->form }}

--- a/src/Filament/Resources/FilamentFormResource.php
+++ b/src/Filament/Resources/FilamentFormResource.php
@@ -7,9 +7,9 @@ use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TagsInput;
-use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Notifications\Notification;
@@ -99,7 +99,7 @@ class FilamentFormResource extends Resource
                     ->dehydrateStateUsing(fn ($state, ?FilamentForm $record): bool => static::userCannotChangePrivateEntries($record) && $record
                         ? (bool) $record->private_entries
                         : (bool) $state),
-                Textarea::make('description')
+                RichEditor::make('description')
                     ->columnSpanFull(),
                 Section::make('Notifications')
                     ->description('Configure email notifications for form submissions')


### PR DESCRIPTION
## Summary
Enables the form **Description** field to store and display rich text/HTML instead of plain text.

## Changes
- **FilamentFormResource**: Replaced `Textarea::make('description')` with `RichEditor::make('description')` so admins can use bold, lists, links, etc.
- **show.blade.php**: Render description as HTML with `{!! ... !!}` inside a conditional block with prose styling. Content is admin-controlled.
- No migration; existing `text` column is sufficient (~64 KB).

## Testing
- Edit a form in admin, add rich text to Description, save and reopen to confirm persistence.
- View the form's public URL and confirm description displays with formatting (paragraphs, lists) instead of smooshed plain text.
- Existing plain-text descriptions continue to render as before.

Made with [Cursor](https://cursor.com)