### PR TITLE
Use policy for viewing form entries when app registers one

### DIFF
--- a/src/Filament/Pages/ShowEntry.php
+++ b/src/Filament/Pages/ShowEntry.php
@@ -64,9 +64,15 @@ class ShowEntry extends Page
                 abort(403, 'This link has expired or is invalid.');
             }
         } else {
-            // For authenticated user entries, only allow if they're the submitter
+            // For authenticated user entries: use policy if registered, otherwise only allow submitter
             if (auth()->check()) {
-                if ($entry->user_id !== auth()->id()) {
+                $user = auth()->user();
+                $policy = policy($entry);
+                if ($policy && method_exists($policy, 'view')) {
+                    if (! $user->can('view', $entry)) {
+                        abort(403, 'You do not have permission to view this form submission.');
+                    }
+                } elseif ($entry->user_id !== $user->id) {
                     abort(403, 'You can only view your own form submissions.');
                 }
             } else {


### PR DESCRIPTION
## Summary
When the consuming app registers a policy for `FilamentFormUser` with a `view()` method, `ShowEntry` uses `$user->can('view', $entry)` instead of only allowing the submitter. Falls back to submitter-only when no policy is present.

## Behavior
- **Guest entries** (`user_id` null): still require valid signed URL.
- **Authenticated entries**: If `policy($entry)` has `view` method → use that; else only allow owner.

Allows apps to grant e.g. admins permission to view any form entry via `FilamentFormUserPolicy::view()`.

Made with [Cursor](https://cursor.com)