### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,9 +18,12 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3]
-        laravel: [12.*, 11.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
+            pest: ^4.0
           - laravel: 12.*
             testbench: 10.*
             pest: ^4.0

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "filament/filament": "^5.0|^4.0",
         "illuminate/contracts": "^11.0||^12.0||^13.0",
         "maatwebsite/excel": "^3.1",
-        "spatie/eloquent-sortable": "^4.3",
+        "spatie/eloquent-sortable": "^4.3|^5.0",
         "spatie/laravel-medialibrary": "^11.12",
         "spatie/laravel-package-tools": "^1.16"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.3",
         "filament/filament": "^5.0|^4.0",
-        "illuminate/contracts": "^11.0||^12.0",
+        "illuminate/contracts": "^11.0||^12.0||^13.0",
         "maatwebsite/excel": "^3.1",
         "spatie/eloquent-sortable": "^4.3",
         "spatie/laravel-medialibrary": "^11.12",


### PR DESCRIPTION
## Summary

- Added `^13.0` to the `illuminate/contracts` version constraint in `composer.json`
- Added Laravel 13 to the CI test matrix in `run-tests.yml` with `testbench: 11.*` and `pest: ^4.0`

## Test plan

- [ ] CI passes for all Laravel/PHP matrix combinations including Laravel 13