### PR TITLE
Fix RichEditor toolbar actions crashing in Show component (v4.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `Filament-Form-Builder` will be documented in this file.
 
+## v4.3.1 - 2026-04-22
+
+### What's Changed
+
+* Fix RichEditor toolbar actions (e.g. link) crashing in Show component by adding `HasActions` / `InteractsWithActions`
+
+**Full Changelog**: https://github.com/TappNetwork/Filament-Form-Builder/compare/v4.3.0...v4.3.1
+
 ## v4.3.0 - 2026-04-14
 
 ### What's Changed

--- a/src/Livewire/FilamentForm/Show.php
+++ b/src/Livewire/FilamentForm/Show.php
@@ -2,9 +2,9 @@
 
 namespace Tapp\FilamentFormBuilder\Livewire\FilamentForm;
 
-use Filament\Forms\Components\Field;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Field;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Schemas\Schema;
@@ -23,7 +23,7 @@ use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
 /**
  * @property Schema $form
  */
-class Show extends Component implements HasForms, HasActions
+class Show extends Component implements HasActions, HasForms
 {
     use InteractsWithActions;
     use InteractsWithForms;

--- a/src/Livewire/FilamentForm/Show.php
+++ b/src/Livewire/FilamentForm/Show.php
@@ -3,6 +3,8 @@
 namespace Tapp\FilamentFormBuilder\Livewire\FilamentForm;
 
 use Filament\Forms\Components\Field;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Schemas\Schema;
@@ -21,8 +23,9 @@ use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
 /**
  * @property Schema $form
  */
-class Show extends Component implements HasForms
+class Show extends Component implements HasForms, HasActions
 {
+    use InteractsWithActions;
     use InteractsWithForms;
     use WithFileUploads;
 


### PR DESCRIPTION
## Summary

- Adds `HasActions` interface and `InteractsWithActions` trait to the `Show` Livewire component
- Fixes a fatal error when Filament's `RichEditor` toolbar (e.g. the **link** button) calls `mountAction()` via Livewire — the component was missing the actions contract
- Bumps changelog to v4.3.1

## Root Cause

`Filament\Forms\Components\RichEditor` dispatches `mountAction('link', ...)` to the hosting Livewire component when the user clicks a toolbar button. The `Show` component only implemented `HasForms`, so Livewire couldn't resolve the method, resulting in an exception.

## Test plan

- [ ] Render a form with a `RichEditor` field via the `Show` component
- [ ] Click the **Link** toolbar button — should open the link modal without error
- [ ] Submit the form — should still save correctly
- [ ] Verify no regression on forms without `RichEditor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)