### PR TITLE
Drop PHP 8.2, add PHP 8.5 to CI matrix

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3]
+        php: [8.5, 8.4, 8.3]
         laravel: [13.*, 12.*]
         stability: [prefer-stable]
         include:


### PR DESCRIPTION
## Summary

- Removes PHP 8.2 from supported versions (composer.json already requires `^8.3`)
- Adds PHP 8.5 to the test matrix in `run-tests.yml`
- Updates PHPStan workflow to run on PHP 8.5

## Changes

- `.github/workflows/run-tests.yml`: Matrix updated from `[8.4, 8.3]` → `[8.5, 8.4, 8.3]`
- `.github/workflows/phpstan.yml`: PHP version updated from `8.3` → `8.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)