### PR TITLE
Bump maatwebsite/excel to ^4.0 on 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.3",
         "filament/filament": "^5.0|^4.0",
         "illuminate/contracts": "^13.0||^12.0",
-        "maatwebsite/excel": "^3.1",
+        "maatwebsite/excel": "^4.0",
         "spatie/eloquent-sortable": "^5.0",
         "spatie/laravel-medialibrary": "^11.12",
         "spatie/laravel-package-tools": "^1.16"


### PR DESCRIPTION
## Summary

Updates the `maatwebsite/excel` Composer constraint from `^3.1` to `^4.0` so the package aligns with Laravel Excel 4.x on the `4.x` branch.

## Why

Laravel Excel 4.x is the current major line; keeping the dependency on ^4.0 allows consumers to install compatible releases and stay on supported APIs.

## Changes

- `composer.json`: require `maatwebsite/excel` `^4.0` instead of `^3.1`.

Made with [Cursor](https://cursor.com)